### PR TITLE
#164198141 Integrate codeclimate test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,12 @@ jobs:
             
       # install dependencies
       - run: npm install
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+          # download test reporter as a static binary
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
 
       - save_cache:
           paths:
@@ -35,5 +41,12 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # run tests!
-      - run: npm test
+      - run:
+          name: Run tests and coverage
+          command: |
+          # notify Code Climate of a pending test report using `before-build`
+            ./cc-test-reporter before-build
+            npm test -- --coverage
+          # upload test report to Code Climate using `after-build`
+            ./cc-test-reporter after-build --exit-code $?
       

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Authors Haven - A Social platform for the creative at heart.
 =======
 
+[![Test Coverage](https://api.codeclimate.com/v1/badges/6097e61ece735ce73806/test_coverage)](https://codeclimate.com/github/andela/apollo-ah-frontend/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/6097e61ece735ce73806/maintainability)](https://codeclimate.com/github/andela/apollo-ah-frontend/maintainability)
+
 ## Vision
 Create a community of like minded authors to foster inspiration and innovation
 by leveraging the modern web.


### PR DESCRIPTION
**What does this PR do?**
This PR integrates code climate test coverage.

**Description of Task to be completed?**
- add repository to codeclimate.
- add codeclimate test coverage badge to `readme` file.
- add codeclimate maintainability badge to `readme` file.

**How should this be manually tested**
- Follow this [link](https://github.com/andela/apollo-ah-frontend)
- Look at the displayed `README.md`, there are badges there for both test coverage and maintainability which displays the percentage of test covered.
- if it's not yet there in the `master` branch, switch to another branch.

**What are the relevant pivotal tracker stories**
[#164198141](https://www.pivotaltracker.com/n/projects/2313263/stories/164198141)

**Screenshots**
N/A