### PR TITLE
#165413442 Resolve issue with webpack config failure to load app

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -25,7 +25,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'bundle.js',
-    publicPath: './',
+    publicPath: '/',
   },
   resolve: {
     extensions: ['.jsx', '.js', '.json', '.scss', '.css']

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -14,7 +14,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'bundle.js',
-    publicPath: './',
+    publicPath: '/',
   },
   resolve: {
     extensions: ['.jsx', '.js', '.json', '.css']


### PR DESCRIPTION
#### What does this PR do?

This provides a resolve to an issue where the app fails to load on a development environment.
PR #17

<img width="1440" alt="Screenshot 2019-04-17 at 12 02 09 PM" src="https://user-images.githubusercontent.com/30989030/56287458-48cac800-6114-11e9-896b-449a492b1a54.png">

#### How should this be manually tested

1. Clone repo by running the following command on your terminal:

```bash
git clone -b bug/165413442/fix-app-loading-failure --single-branch \
https://github.com/andela/apollo-ah-frontend.git
```

2. Navigate into the repo directory: `cd apollo-ah-frontend`

2. Install dependency packages with: `npm install`

3. On the root directory, create a `.env` file from `.env.example` and provide required credentials

4. Spin up the server with: `npm run start:dev -- --open`

#### What are the relevant pivotal tracker stories?

[165413442](https://www.pivotaltracker.com/story/show/165413442)
[165212485](https://www.pivotaltracker.com/story/show/165212485)