### PR TITLE
#166187940 Getting articles on the homepage returns an error

### DIFF
--- a/src/reducers/articleReducer.js
+++ b/src/reducers/articleReducer.js
@@ -43,7 +43,7 @@ export default (state = initialState, action) => {
       return {
         ...state,
         loading: false,
-        articles: '',
+        articles: [],
         error,
       };
     default:

--- a/src/test/components/__snapshots__/SingleArticle.test.js.snap
+++ b/src/test/components/__snapshots__/SingleArticle.test.js.snap
@@ -297,7 +297,7 @@ After the success of Peloton’s stationary bike — it has sold hundreds of
                                   Anonymous Lekan
                                 </h6>
                                 <span>
-                                  17 days ago
+                                  about 1 month ago
                                 </span>
                                 <span
                                   className="article-author-dot"

--- a/src/test/reducers/acticleReducer.test.js
+++ b/src/test/reducers/acticleReducer.test.js
@@ -48,13 +48,13 @@ describe('Reset password reducer: ', () => {
   it('should update the reducer state when unsuccessful', () => {
     const action = {
       type: getArticlesType.failure,
-      articles: '',
+      articles: [],
       error: '',
       loading: false
     };
     const result = articleReducer(articleState, action);
     const expected = {
-      ...articleState, loading: false, articles: '', error: ''
+      ...articleState, loading: false, articles: [], error: ''
     };
     expect(result).toEqual(expected);
   });

--- a/src/test/views/__snapshots__/ArticleBody.test.js.snap
+++ b/src/test/views/__snapshots__/ArticleBody.test.js.snap
@@ -40,7 +40,7 @@ exports[`<ArticleBody /> should take a snapshot of the component 1`] = `
             Anonymous Lekan
           </h6>
           <span>
-            17 days ago
+            about 1 month ago
           </span>
           <span
             className="article-author-dot"


### PR DESCRIPTION
#### What does this PR do?
It fixes the error return while get articles on the homepage

#### Description of task to be completed?
- modify the value of the key `articles` base on the condition getArticlesType.failure

#### How should this be manually tested?
- Follow the steps below:
  - Run the following commands in your terminal
`git clone https://github.com/andela/apollo-ah-frontend.git`
`cd apollo-ah-frontend`
- Run `npm install` to install all dependencies.
- Run `npm run build`.
- Start the app by running `node serve` and open up `http://localhost:3001/` in your browser.
#### What are the relevant pivotal tracker stories?
[#166187940](https://www.pivotaltracker.com/story/show/166187940)
#### Screenshots (if appropriate)
N/A
